### PR TITLE
Allow for constant shadow of parameters

### DIFF
--- a/src/Ariadne.jl
+++ b/src/Ariadne.jl
@@ -36,7 +36,7 @@ abstract type AbstractJacobianOperator end
 
 Efficient implementation of `J(f,x,p) * v` and `v * J(f, x,p)'`
 """
-struct JacobianOperator{F, F′::Union{Nothing, F}, A, P, P′::Union{Nothing, P}} <: AbstractJacobianOperator
+struct JacobianOperator{F, F′, A, P, P′} <: AbstractJacobianOperator
     f::F # F!(res, u, p)
     f′::F′ # cache
     res::A

--- a/src/Ariadne.jl
+++ b/src/Ariadne.jl
@@ -36,18 +36,33 @@ abstract type AbstractJacobianOperator end
 
 Efficient implementation of `J(f,x,p) * v` and `v * J(f, x,p)'`
 """
-struct JacobianOperator{F, A, P} <: AbstractJacobianOperator
+struct JacobianOperator{F, F′::Union{Nothing, F}, A, P, P′::Union{Nothing, P}} <: AbstractJacobianOperator
     f::F # F!(res, u, p)
-    f′::Union{Nothing, F} # cache
+    f′::F′ # cache
     res::A
     u::A
     p::P
-    p′::Union{Nothing, P} # cache
-    function JacobianOperator(f::F, res, u, p) where {F}
-        f′ = init_cache(f)
+    p′::P′ # cache
+end
+
+"""
+    JacobianOperator(f::F, res, u, p; assume_p_const::Bool = false)
+
+Creates a Jacobian operator for `f!(res, u, p)` where `res` is the residual,
+`u` is the state variable, and `p` are the parameters.
+
+If `assume_p_const` is `true`, the parameters `p` are assumed to be constant
+during the Jacobian computation, which can improve performance by not requiring the
+shadow for `p`.
+"""
+function JacobianOperator(f::F, res, u, p; assume_p_const::Bool = false) where {F}
+    f′ = init_cache(f)
+    if assume_p_const
+        p′ = nothing
+    else
         p′ = init_cache(p)
-        return new{F, typeof(u), typeof(p)}(f, f′, res, u, p, p′)
     end
+    return JacobianOperator(f, f′, res, u, p, p′)
 end
 
 batch_size(::JacobianOperator) = 1


### PR DESCRIPTION
```
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  209.890 μs …   2.602 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     353.338 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   436.954 μs ± 219.453 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

     ▂██▅▂                                                       
  ▂▂▄██████▆▆▅▅▅▄▄▃▃▃▃▂▃▂▂▂▂▂▂▂▂▂▂▂▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  210 μs           Histogram: frequency by time         1.31 ms <

 Memory estimate: 124.36 KiB, allocs estimate: 2826.

BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  20.368 μs … 442.233 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     29.145 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   31.249 μs ±   9.730 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

      ▄▂▃█▄▅▄▃▃▂▁▁                                              
  ▂▃▂▅█████████████▇▇▆▆▅▄▄▃▃▃▃▃▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  20.4 μs         Histogram: frequency by time           64 μs <

 Memory estimate: 4.44 KiB, allocs estimate: 87.
```